### PR TITLE
strptime was failing on identi.ca output like '2013-07-05T17:48:53+00:00'

### DIFF
--- a/pypump/models/__init__.py
+++ b/pypump/models/__init__.py
@@ -33,9 +33,6 @@ class AbstractModel(object):
 
     _pump = None
 
-    # constants
-    TSFORMAT = "%Y-%m-%dT%H:%M:%SZ"
-
     def __init__(self, pypump=None, *args, **kwargs):
         """ Sets up pump instance """
         if pypump:

--- a/pypump/models/comment.py
+++ b/pypump/models/comment.py
@@ -16,6 +16,7 @@
 ##
 
 from datetime import datetime
+from dateutil.parser import parse
 
 from pypump.models import AbstractModel
 from pypump.compatability import *
@@ -155,13 +156,13 @@ class Comment(AbstractModel):
     def unserialize(cls, data, obj=None):
         """ from JSON -> Comment """
         if "object" in data:
-            published = datetime.strptime(data["object"]["published"], Comment.TSFORMAT)
-            updated = datetime.strptime(data["object"]["updated"], Comment.TSFORMAT)
+            published = parse(data["object"]["published"])
+            updated = parse(data["object"]["updated"])
             summary = data["content"]
             content = data["object"]["content"]
         else:
-            published = datetime.strptime(data["published"], Comment.TSFORMAT)
-            updated = datetime.strptime(data["updated"], Comment.TSFORMAT)
+            published = parse(data["published"])
+            updated = parse(data["updated"])
             summary = ""
             content = data["content"]
 

--- a/pypump/models/note.py
+++ b/pypump/models/note.py
@@ -17,6 +17,7 @@
 
 import json
 from datetime import datetime
+from dateutil.parser import parse
 
 from pypump.exception.ImmutableException import ImmutableException
 from pypump.exception.PumpException import PumpException
@@ -289,8 +290,8 @@ class Note(AbstractModel):
 
         deleted_note.id = data["id"] if "id" in data else ""
         deleted_note.actor = deleted_note._pump.Person.unserialize(data["actor"])        
-        deleted_note.updated = datetime.strptime(data["updated"], cls.TSFORMAT)
-        deleted_note.published = datetime.strptime(data["published"], cls.TSFORMAT)
+        deleted_note.updated = parse(data["updated"])
+        deleted_note.published = parse(data["published"])
 
         return deleted_note
 
@@ -327,8 +328,8 @@ class Note(AbstractModel):
                     to=(), # todo still.
                     cc=(), # todo: ^^
                     actor=cls._pump.Person.unserialize(data["actor"]),
-                    updated=datetime.strptime(data["updated"], cls.TSFORMAT),
-                    published=datetime.strptime(data["published"], cls.TSFORMAT),
+                    updated=parse(data["updated"]),
+                    published=parse(data["published"]),
                     links=links,
                     )
         else:
@@ -336,7 +337,7 @@ class Note(AbstractModel):
             obj.summary = summary
             obj.id = nid
             obj.actor = cls._pump.Person.unserialize(data["actor"]) if "actor" in data else obj.actor
-            obj.updated = datetime.strptime(data["updated"], cls.TSFORMAT)
-            obj.published = datetime.strptime(data["published"], cls.TSFORMAT)
+            obj.updated = parse(data["updated"])
+            obj.published = parse(data["published"])
             obj._links = links
             return obj

--- a/pypump/models/person.py
+++ b/pypump/models/person.py
@@ -16,6 +16,7 @@
 ##
 
 from datetime import datetime
+from dateutil.parser import parse
 
 from requests_oauthlib import OAuth1
 
@@ -201,8 +202,8 @@ class Person(AbstractModel):
         """ Unserializes the data from a service """
         id = data["id"]
         display = data["displayName"]
-        updated = datetime.strptime(data["updated"], cls.TSFORMAT) if "updated" in data else datetime.now()
-        published = datetime.strptime(data["published"], cls.TSFORMAT) if "published" in data else updated
+        updated = parse(data["updated"]) if "updated" in data else datetime.now()
+        published = parse(data["published"]) if "published" in data else updated
 
         if obj is None:
             obj = cls()
@@ -236,10 +237,10 @@ class Person(AbstractModel):
         self.display_name = display
         self.url = data["links"]["self"]["href"]
         self.summary = data["summary"] if "summary" in data else ""
-        self.updated = datetime.strptime(data["updated"], cls.TSFORMAT) if "updated" in data else datetime.now()
-        self.published = datetime.strptime(data["published"], cls.TSFORMAT) if "published" in data else self.updated
+        self.updated = parse(data["updated"]) if "updated" in data else datetime.now()
+        self.published = parse(data["published"]) if "published" in data else self.updated
         self.me = True if "acct:%s@%s" % (cls._pump.nickname, cls._pump.server) == self.id else False
         self.location = cls._pump.Location.unserialize(data["location"]) if "location" in data else None
 
-        self.updated = datetime.strptime(data["updated"], cls.TSFORMAT) if "updated" in data else datetime.now()
+        self.updated = parse(data["updated"]) if "updated" in data else datetime.now()
         return self

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
                 "requests-oauthlib>=0.3.0",
                 "requests>=1.2.0",
                 "nose",
+                "python-dateutil>=2.1",
                 ],
         classifiers=[
                 "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Note that this patch adds a dependency on python-dateutil.

I only tested that the error with inbox notes went away, not any of the other strptimes.
