### PR TITLE
Fix id for foreign unserialized persons

### DIFF
--- a/pypump/models/person.py
+++ b/pypump/models/person.py
@@ -231,7 +231,7 @@ class Person(AbstractModel):
             # This will be fixed properly soon.
             return None
 
-        self.id = "acct:%s@%s" % (username, cls._pump.server)
+        self.id = data["id"]
         self.username = username
         self.display_name = display
         self.url = data["links"]["self"]["href"]


### PR DESCRIPTION
The server part of a unserialized Person's id was always set to pypump.server
even if their account were on a foreign server
