### PR TITLE
Unserialize remote Persons on init

### DIFF
--- a/pypump/models/person.py
+++ b/pypump/models/person.py
@@ -99,14 +99,15 @@ class Person(AbstractModel):
                 self.username = username
                 self.server = server
                 self.is_self = False
-                url = "{server}/api/user/{username}/profile".format(
+                url = "{proto}://{server}/api/user/{username}/profile".format(
+                        proto=self._pump.protocol,
                         server=self.server,
                         username=self.username
                         )
 
-                return
                 # register client as we need to use the client credentials
                 self.register_client()
+                data = self._pump.request(url, raw=True, client=self.client)
             self.unserialize(data, obj=self)
             return
 

--- a/pypump/openid.py
+++ b/pypump/openid.py
@@ -81,7 +81,15 @@ class OpenID(object):
                 "data": data
                 }
 
-        response = self.pypump._requester(requests.post, self.ENDPOINT, **request)
+        if self.server == self.pypump.server:
+            response = self.pypump._requester(requests.post, self.ENDPOINT, **request)
+        else:
+            url = "{proto}://{server}/{endpoint}".format(
+                proto=self.pypump.protocol,
+                server = self.server,
+                endpoint = self.ENDPOINT
+            )
+            response = self.pypump._requester(requests.post, url, raw=True, **request)
         
         try:
             server_data = response.json()


### PR DESCRIPTION
Changed OpenID to use raw request if OpenID.server != PyPump.server
On Person init, use register_client to get Person data from remote
server.
