### PR TITLE
Fix Person.__repr__()

### DIFF
--- a/pypump/models/person.py
+++ b/pypump/models/person.py
@@ -193,7 +193,7 @@ class Person(AbstractModel):
         return True
 
     def __repr__(self):
-        return self.id.lstrip("acct:")
+        return self.id.replace("acct:", "")
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
Change `.lstrip("acct:")` to `.replace("acct:", "")`

`str.lstrip("acct:")` strips all combinations of `"acct:"` from `str`
For example `"acct:tactic@identi.ca".lstrip("acct:")` returns
`"ic@identi.ca"`
