### PR TITLE
minor typos and grammar/style changes

### DIFF
--- a/docs/gettingstarted/verifier_callback.rst
+++ b/docs/gettingstarted/verifier_callback.rst
@@ -2,13 +2,13 @@
 Getting Verifier
 ================
 
-As part of OAuth to allow OOB (Out of band) applications to have access to the account
-we have a link that they will click, follow the instructions and then copy the verifier
-into the application which we then relay to the server with other tokens. The server
-will them provide us with the credentials that we can use.
+For OAuth to allow OOB (Out of band) applications to have access to an account,
+we must provide a link, instructions, and a means of copying the verifier into an application
+and relaying it to the server with other tokens. The server
+will then provide us with the credentials that we can use.
 
-You will need to write a method which takes a URL that the user needs to visit and provides
-some way for that user to input a string value, which you will then give to PyPump. This could
+You must write a method which takes a URL that the user needs to visit, provide some 
+way for that user to input a string value (the verification), and then give that value to PyPump. This could
 be simply a case of printing the link and using raw_input/input to get the verifier or it could
 be a more complex function which redraws a GUI and opens a browser. 
 

--- a/docs/gettingstarted/verifier_callback.rst
+++ b/docs/gettingstarted/verifier_callback.rst
@@ -3,9 +3,9 @@ Getting Verifier
 ================
 
 For OAuth to allow OOB (Out of band) applications to have access to an account,
-we must provide a link, instructions, and a means of copying the verifier into an application
-and relaying it to the server with other tokens. The server
-will then provide us with the credentials that we can use.
+first we must provide a link and instructions for the user. Then we must provide
+a means of copying the verifier into an application and relaying it to the server
+with other tokens. The server will then provide us with the credentials that we can use.
 
 You must write a method which takes a URL that the user needs to visit, provide some 
 way for that user to input a string value (the verification), and then give that value to PyPump. This could

--- a/docs/gettingstarted/verifier_callback.rst
+++ b/docs/gettingstarted/verifier_callback.rst
@@ -7,10 +7,10 @@ we have a link that they will click, follow the instructions and then copy the v
 into the application which we then relay to the server with other tokens. The server
 will them provide us with the credentials that we can use.
 
-You will need to write a method which takes a URL that the user needs to visit and provide
-some way of the users inputting string value which you will then give to PyPump. This could
-just be a case of printing the link and using raw_input/input to get the verifier or it could
-be a more complex funtion which redraws a GUI and opens a browser. 
+You will need to write a method which takes a URL that the user needs to visit and provides
+some way for that user to input a string value, which you will then give to PyPump. This could
+be simply a case of printing the link and using raw_input/input to get the verifier or it could
+be a more complex function which redraws a GUI and opens a browser. 
 
 
 Simple verifier
@@ -29,8 +29,8 @@ verifier in the PyPump Shell::
 Callback
 --------
 
-Having a function which is called and then returns back the verification might be more
-difficult in GUI programs or other interfaces. We provide a callback mechamism that you
+Having a function which is called and then returns the verification might be more
+difficult in GUI programs or other interfaces. We provide a callback mechanism that you
 can use. If the verifier function returns None then PyPump assumes you will be
 calling PyPump.verifier which takes the verifier as the argument.
 
@@ -52,7 +52,7 @@ one up in order to demonstrate exactly what might be involved::
             self.draw("Please wait, loading...")
 
             # setup pypump object
-            clinet = Client(
+            client = Client(
                 webfinger='someone@server.com',
                 type='native',
                 name='An awesome GUI client'


### PR DESCRIPTION
mostly typos and some subtle style/grammar changes.

In the **second paragraph**, the subject for "provide" could possibly be the *method* and not the *programmer* ("you"). Maybe it is more general or accurate to say that the "author must provide" (rather than "write a method which provides") a means for inputing the verification string. Otherwise I would change the sentence to (with the method as subject):

"You must write a method which takes a URL that the user needs to visit and provides
some way for that user to input a string value, which you then give to PyPump."

(I figure this process could be split in two methods? But it'll generally be in one?)

In the **first paragraph**, I am not literate in the OAuth protocol, so my edits could very well be wrong (although there is something off going on with subject-verb agreements). I notice the procedure is very similar to the second paragraph, maybe the two paragraphs could be merged? Or maybe the first paragraph rather a higher level explanation?

