### PR TITLE
Adding print parentheses to docs

### DIFF
--- a/docs/gettingstarted/authentication.rst
+++ b/docs/gettingstarted/authentication.rst
@@ -23,7 +23,7 @@ The following will create (for the first time) a connection to a pump.io server 
     ...     type="native"
     ...)
     >>> def simple_verifier(url):
-    ...     print 'Go to: ' + url
+    ...     print('Go to: ' + url)
     ...     return raw_input('Verifier: ') # they will get a code back
     >>> pump = PyPump(client=client, verifier_callback=simple_verifier)
 

--- a/docs/gettingstarted/qnd.rst
+++ b/docs/gettingstarted/qnd.rst
@@ -22,8 +22,8 @@ to take a URL and have the user allow our application this function can either r
 the verification code or you can call pump.verify(code), a simple code::
 
     >>> def simple_verifier(url):
-    ...     print 'Please follow the instructions at the following URL:'
-    ...     print url
+    ...     print('Please follow the instructions at the following URL:')
+    ...     print(url)
     ...     return raw_input("Verifier: ") # the verifier is a string
 
 .. note:: If you wish to call pump.verify(<verification code>) return None from your verifier function

--- a/docs/gettingstarted/tutorial.rst
+++ b/docs/gettingstarted/tutorial.rst
@@ -57,7 +57,7 @@ your first time, you need to authenticate this client::
     ...     name="Test.io"
     ...     )
     >>> def simple_verifier(url):
-    ...     print 'Go to: ' + url
+    ...     print('Go to: ' + url)
     ...     return raw_input('Verifier: ') # they will get a code back
     >>> pump = PyPump(client=client, verifier_callback=simple_verifier)
 

--- a/docs/gettingstarted/verifier_callback.rst
+++ b/docs/gettingstarted/verifier_callback.rst
@@ -22,8 +22,8 @@ verifier in the PyPump Shell::
 
     def verifier(url):
         """ Asks for verification code for OAuth OOB """
-        print "Please open and follow the instructions:"
-        print url
+        print("Please open and follow the instructions:")
+        print(url)
         return raw_input("Verifier: ")
 
 Callback


### PR DESCRIPTION
In python3 we need parentheses for `print`. That is already done in the code, but a few sections in the documentation didn't have it. Small change, but helps when users are copy/pasting from documentation to the prompt.