### PR TITLE
[WIP] Use OAuth1Session for signed requests in pump.request()

### DIFF
--- a/pypump/pypump.py
+++ b/pypump/pypump.py
@@ -345,13 +345,9 @@ class PyPump(object):
             url = endpoint
 
         kwargs["verify"] = self.verify_requests
-        kwargs["allow_redirects"] = False
 
         try:
             response = fnc(url, **kwargs)
-            if response.is_redirect:
-                url = response.headers["location"]
-                response = fnc(url, **kwargs)
             return response
         except requests.exceptions.ConnectionError:
             if (self.verify_requests and self.protocol == "https") or raw:

--- a/pypump/pypump.py
+++ b/pypump/pypump.py
@@ -279,14 +279,14 @@ class PyPump(object):
             url = endpoint
 
         headers = headers or {"Content-Type": "application/json"}
-        if client is None:
-            request = {
-                "headers": headers,
-                "params": params,
-                "timeout": timeout,
-         }
-            request.update(kwargs)
+        request = {
+            "headers": headers,
+            "params": params,
+            "timeout": timeout,
+        }
+        request.update(kwargs)
 
+        if client is None:
             if method == "POST":
                 fnc = requests.post
                 request.update({"data": data})
@@ -304,12 +304,6 @@ class PyPump(object):
                                 resource_owner_key=c.resource_owner_key,
                                 resource_owner_secret=c.resource_owner_secret
                                )
-            request = {
-                "headers": headers,
-                "params": params,
-                "timeout": timeout,
-            }
-            request.update(kwargs)
 
             if method == "POST":
                 fnc = oas.post

--- a/pypump/pypump.py
+++ b/pypump/pypump.py
@@ -518,8 +518,6 @@ class WebPump(PyPump):
         if "oauth-access-token" not in self.store:
             return False
 
-        # if it redirects to the profile it'll raise an exception as
-        # it doesn't sign the redirection request.
         response = self.request("/api/whoami", allow_redirects=False)
 
         # It should response with a redirect to our profile if it's logged in

--- a/pypump/pypump.py
+++ b/pypump/pypump.py
@@ -345,9 +345,13 @@ class PyPump(object):
             url = endpoint
 
         kwargs["verify"] = self.verify_requests
+        kwargs["allow_redirects"] = False
 
         try:
             response = fnc(url, **kwargs)
+            if response.is_redirect:
+                url = response.headers["location"]
+                response = fnc(url, **kwargs)
             return response
         except requests.exceptions.ConnectionError:
             if (self.verify_requests and self.protocol == "https") or raw:

--- a/pypump/pypump.py
+++ b/pypump/pypump.py
@@ -280,7 +280,6 @@ class PyPump(object):
 
         headers = headers or {"Content-Type": "application/json"}
         if client is None:
-            fnc = requests.get
             request = {
                 "headers": headers,
                 "params": params,

--- a/pypump/pypump.py
+++ b/pypump/pypump.py
@@ -265,8 +265,14 @@ class PyPump(object):
         # check client has been setup
         if client is None:
             client = self.setup_oauth_client(endpoint)
+            c = client.client
+            fnc = OAuth1Session(c.client_key,
+                                client_secret=c.client_secret,
+                                resource_owner_key=c.resource_owner_key,
+                                resource_owner_secret=c.resource_owner_secret
+                               )
         elif client is False:
-            client = None
+            fnc = requests
 
         params = {} if params is None else params
 
@@ -286,35 +292,16 @@ class PyPump(object):
         }
         request.update(kwargs)
 
-        if client is None:
-            if method == "POST":
-                fnc = requests.post
-                request.update({"data": data})
-            elif method == "PUT":
-                fnc = requests.put
-                request.update({"data": data})
-            elif method == "GET":
-                fnc = requests.get
-            elif method == "DELETE":
-                fnc = requests.delete
-        else:
-            c = client.client
-            oas = OAuth1Session(c.client_key,
-                                client_secret=c.client_secret,
-                                resource_owner_key=c.resource_owner_key,
-                                resource_owner_secret=c.resource_owner_secret
-                               )
-
-            if method == "POST":
-                fnc = oas.post
-                request.update({"data": data})
-            elif method == "PUT":
-                fnc = oas.put
-                request.update({"data": data})
-            elif method == "GET":
-                fnc = oas.get
-            elif method == "DELETE":
-                fnc = oas.delete
+        if method == "POST":
+            fnc = fnc.post
+            request.update({"data": data})
+        elif method == "PUT":
+            fnc = fnc.put
+            request.update({"data": data})
+        elif method == "GET":
+            fnc = fnc.get
+        elif method == "DELETE":
+            fnc = fnc.delete
 
         for attempt in range(1 + retries):
             response = self._requester(


### PR DESCRIPTION
Fix for #120 
**Update**: We're now using OAuth1Session instead of manual redirects

Was:

> Adding this as a PR since i'm not yet sure if this is the way to go.
> We lose the ability to control if we should follow redirects f.ex `pump.prequest(url, allow_redirects=False)` as this change would mean we always follow redirects.
> 
> Maybe it's a good enough compromise for now, as the only other solution (afaik) is to rewrite PyPump to use OAuth1Session instead of OAuth1, and that's a much bigger task.
> 

Comments welcome :)