### PR TITLE
Requests headers requires a str or bytes, and no longer accepts int

### DIFF
--- a/pypump/models/__init__.py
+++ b/pypump/models/__init__.py
@@ -613,7 +613,7 @@ class Uploadable(Addressable):
         mimetype = mimetypes.guess_type(filename)[0] or "application/octal-stream"
         headers = {
             "Content-Type": mimetype,
-            "Content-Length": os.path.getsize(filename),
+            "Content-Length": str(os.path.getsize(filename)),
         }
 
         # upload file


### PR DESCRIPTION
According to https://github.com/kennethreitz/requests/issues/3477 they no longer accept integers for the header parameter. Converting to string will resolve the issue.

This resolves https://github.com/xray7224/p/issues/42
